### PR TITLE
Nav should always display in block

### DIFF
--- a/bootswatch.less
+++ b/bootswatch.less
@@ -467,7 +467,7 @@ input[type="checkbox"],
 
 // Navs =======================================================================
 .nav{
-  display: flex;
+  display: block;
   &-tabs {
     > li > a,
     > li > a:focus {


### PR DESCRIPTION
The aftermath will only be noticed in a _justified_ nav.

Flex
![image](https://cloud.githubusercontent.com/assets/1596656/12442593/c185ed90-bf16-11e5-86d1-94dbc01212a4.png)

Block
![image](https://cloud.githubusercontent.com/assets/1596656/12442611/f6edb2ce-bf16-11e5-8356-bda68df3482c.png)
